### PR TITLE
/var/run/slapd also has to be accessible to slapd

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ ulimit -n 8192
 
 set -e
 
-chown -R openldap:openldap /var/lib/ldap/
+chown -R openldap:openldap /var/lib/ldap/ /var/run/slapd/
 
 if [[ ! -d /etc/ldap/slapd.d ]]; then
 


### PR DESCRIPTION
Sharing unix sockets via data-only containers is a viable way of communicating between processes; to do this, however, `/var/run/slapd` has to be on a volume from an external container. There is no guarantee that it will have the correct permissions, hence the need to `chown` it in the entrypoint script.
