### PR TITLE
ignore set -e at grep SLAPD_

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,7 +97,9 @@ EOF
 
     chown -R openldap:openldap /etc/ldap/slapd.d/
 else
+    set +e
     slapd_configs_in_env=`env | grep 'SLAPD_'`
+    set -e
 
     if [ -n "${slapd_configs_in_env:+x}" ]; then
         echo "Info: Container already configured, therefore ignoring SLAPD_xxx environment variables and preseed files"


### PR DESCRIPTION
Because "set -e option in entrypoint.sh"
if `env | grep SLAPD_` (don't set SLAPD_* env) returned an error, shell script stops.

- posix set -e
  http://pubs.opengroup.org/onlinepubs/007904975/utilities/set.html
- grep Exit-status
  https://www.gnu.org/software/grep/manual/grep.html#Exit-Status


```
// Reproduce commands
docker volume create --name etc_ldap
docker volume create --name var_ldap

// 1st execution 
docker run -d \
  -e SLAPD_PASSWORD=mysecretpassword  \
  -e SLAPD_DOMAIN=ldap.example.org    \
  -v etc_ldap:/etc/ldap               \
  -v var_ldap:/var/lib/ldap           \
  dinkel/openldap

// 2nd execution ends immediately
docker run -d \
  -v etc_ldap:/etc/ldap               \
  -v var_ldap:/var/lib/ldap           \
  dinkel/openldap
// OR 
docker run -it \
  -v etc_ldap:/etc/ldap               \
  -v var_ldap:/var/lib/ldap           \
  dinkel/openldap
```