### PR TITLE
Add a way to customize ACL rules in container if required

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,13 @@ Prepopulate with data
 ---------------------
 
 There are some use cases where it is desired to prepopulate the database with 
-some data before launching the container. In order to do that, one can mount a 
+some data or configuration customizations before launching the container. In order to do that, one can mount a 
 host directory as a data volume in `/etc/ldap.dist/prepopulate`. Each LDIF file 
 is run through `slapadd` in alphabetical order. E.g.
 
     docker run -d --volume /path/to/dir/with/ldif-files:/etc/ldap.dist/prepopulate [CONFIG] dinkel/openldap
+
+One can also customize ACL rules of the database by providing `olcAccess` rules in the file named `access.rules` in `/etc/ldap.dist/prepopulate`. If the file does not exist, default rules are applied, otherwise they are replaced by the provided rules.
 
 Please note that the prepopulation files are only processed on the containers 
 first run (a.k.a. as long as there is no data in the database).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,8 @@ ulimit -n 8192
 set -e
 
 SLAPD_FORCE_RECONFIGURE="${SLAPD_FORCE_RECONFIGURE:-false}"
+ACCESS_LDIF="/etc/ldap/prepopulate/access.rules"
+CONFIG_LDIF="/etc/ldap/slapd.d/cn=config/olcDatabase={1}hdb.ldif"
 
 first_run=true
 
@@ -104,11 +106,19 @@ else
     fi
 fi
 
+
 if [[ "$first_run" == "true" ]]; then
     if [[ -d "/etc/ldap/prepopulate" ]]; then 
         for file in `ls /etc/ldap/prepopulate/*.ldif`; do
             slapadd -F /etc/ldap/slapd.d -l "$file"
         done
+
+        if [[ -f "${ACCESS_LDIF}" ]]; then
+             sed "9,12d" ${CONFIG_LDIF} > ${CONFIG_LDIF}.new
+             cat ${ACCESS_LDIF} >> ${CONFIG_LDIF}.new
+             cat ${CONFIG_LDIF}.new > ${CONFIG_LDIF}
+             echo "Access rules customized."
+        fi
     fi
 fi
 

--- a/example/access.rules
+++ b/example/access.rules
@@ -1,0 +1,4 @@
+olcAccess: {0}to attrs=userPassword,shadowLastChange by self write by anonymou
+ s auth by * none 
+# olcAccess: {1}to dn.base="" by * read 
+# olcAccess: {2}to * by * read 


### PR DESCRIPTION
The ACL rules are specified in the file named **access.rules** that must be located in the same directory as the user LDIF files.
If the file exists, the custom ACL rules are applied, otherwise the container uses default rules.