### PR TITLE
Upgrade base image to Debian stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:jessie
+FROM debian:stretch
 
 MAINTAINER Christian Luginbühl <dinkel@pimprecords.com>
 
-ENV OPENLDAP_VERSION 2.4.40
+ENV OPENLDAP_VERSION 2.4.44
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 docker-openldap
 ===============
 
-The image is based on Debian stable ("jessie" at the moment). The Dockerfile is 
-inspired by [cnry/openldap](https://registry.hub.docker.com/u/cnry/openldap/), 
-but as said before, running a stable Debian and be a little less verbose, but 
+The image is based on Debian stable ("stretch" at the moment). The Dockerfile is
+inspired by [cnry/openldap](https://registry.hub.docker.com/u/cnry/openldap/),
+but as said before, running a stable Debian and be a little less verbose, but
 more complete in the configuration.
 
 NOTE: On purpose, there is no secured channel (TLS/SSL), because I believe that


### PR DESCRIPTION
Debian stretch has replaced Debian jessie as the current stable release a few months ago by now. Switching the base image keeps the Docker image up to date, and upgrades OpenLDAP to release 2.4.44. This would fix the inconsistency I reported as issue #24. It might potentially cause minor breakage to automated setups built on the image, as [the Debian changelog for the slapd package](http://ftp-master.metadata.debian.org/changelogs//main/o/openldap/openldap_2.4.44+dfsg-5_changelog) lists various (presumably minor, but not necessarily completely backwards-compatible) changes since version 2.4.40+dfsg-1.